### PR TITLE
Update README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,133 @@
-# LLM Decision Framework
+# ARMOR Benchmark 2025
 
-This project benchmarks the performance of Large Language Models (LLMs) against real-world military decision-making challenges using doctrine-grounded scenarios and policy-aligned prompts.
+ARMOR Benchmark 2025 is a doctrine-grounded benchmark for evaluating how large language models (LLMs) answer multiple-choice questions about military decision-making, law-of-war concepts, rules of engagement, and professional ethics. The benchmark is designed for educational and analytical evaluation of model behavior against source-backed policy documents.
 
-## Overview
+## What is in this repository?
 
-Objective: Evaluate how effectively LLMs can interpret and respond to complex military scenarios by simulating decision-making processes that align with established doctrines and policies
+This repository contains the benchmark dataset, source doctrine PDFs, question-generation and model-evaluation scripts, and aggregate analysis outputs.
 
-Approach: Utilize doctrine-grounded prompts to simulate real-world military decision-making situations.
+| Path | Description |
+| --- | --- |
+| `dataset/questions_final_519.jsonl` | Final benchmark question set in JSON Lines format. Each record includes a question ID, source document, category, answer options, correct option, supporting evidence, and safety/answerability metadata. |
+| `input_policy_documents/` | Source policy and doctrine PDFs used to build the benchmark, including law-of-war, rules-of-engagement, and ethics references. |
+| `question_generation_pipeline/` | Scripts for cleaning doctrine text, generating MCQs with multiple LLMs, finding similar questions, and evaluating model answers. |
+| `llm_preformance_results/` | Per-model result CSVs and aggregated score/refusal summaries. The directory name is preserved as it appears in the project. |
+| `data_analysis_&_outputs/` | Analysis artifacts such as heatmaps, category-level accuracy tables, most-missed questions, similarity pairs, and the analysis notebook. |
+| `requirements.txt` | Python dependencies for generation, evaluation, and analysis workflows. |
 
-Evaluation: Analyze LLM responses for consistency, accuracy, and alignment with established military guidelines.
+## Dataset format
 
-## Repository Structure
+The final benchmark is stored at `dataset/questions_final_519.jsonl`. Each line is a JSON object with fields such as:
 
-* `llm_results/`: Directory housing the results of LLM evaluations.
-   * `model_outputs/`: Raw responses from various LLMs to the benchmark questions. Files are named to reflect the model used.
-   * `evaluation_scores.csv`: Contains scoring results for each model, measuring correctness and category-wise performance.
-   * `summary_heatmaps/`: Visualizations of model performance across doctrinal subcategories (e.g., accuracy heatmaps, confusion matrices).
-     
-* `foundation_prompts/`: Collection of prompts based on military doctrines used to test LLM responses.
-   * Contains CSV files with doctrinally grounded multiple-choice questions.
-   * These are grouped into subcategories: `ethics_questions.csv` based on ethical dilemmas from ADA590672 and `roe_questions.csv` based on rules of engagement from TBS B130936.
-   * Each row in these files includes the question, answer choices, and the correct answer label.
+- `qid`: stable question identifier.
+- `doc_source`: source document family, for example `rules_of_engagement` or `law_of_war_2023`.
+- `category`: doctrinal category for the question.
+- `generator_model`: model family that generated the draft question.
+- `question`: the multiple-choice question text.
+- `option_A`, `option_B`, `option_C`, and optionally `option_D`: answer choices.
+- `correct_option`: correct answer label.
+- `supporting_evidence`: source-backed evidence justifying the answer.
+- `is_allowed_to_answer`: whether the item is intended to be answerable in an educational/doctrinal setting.
 
-## Evaluation Metrics
-* Doctrine Alignment: Measures how well LLM responses align with established military doctrines.
-* Decision Accuracy: Assesses the correctness of decisions made by LLMs in simulated scenarios.
-* Response Consistency: Evaluates the consistency of LLM outputs across similar scenarios.
+## Installation
+
+Create a Python environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Some workflows use hosted model APIs. Set only the keys needed for the providers you plan to run:
+
+```bash
+export OPENAI_API_KEY="..."
+export ANTHROPIC_API_KEY="..."
+export GEMINI_API_KEY="..."
+export TOGETHER_API_KEY="..."
+```
+
+Local Hugging Face model evaluation expects downloaded models under a project-local `models/` directory.
+
+## Evaluating models
+
+Use `question_generation_pipeline/llm_decision_eval.py` to evaluate online or local models against the JSONL benchmark.
+
+Evaluate one online model:
+
+```bash
+python question_generation_pipeline/llm_decision_eval.py \
+  --online_only \
+  --model_name gpt-4o-2024-08-06 \
+  --dataset_path dataset/questions_final_519.jsonl \
+  --output_path outputs
+```
+
+Evaluate all configured online models:
+
+```bash
+python question_generation_pipeline/llm_decision_eval.py \
+  --online_only \
+  --dataset_path dataset/questions_final_519.jsonl \
+  --output_path outputs
+```
+
+Evaluate local models from `models/` only:
+
+```bash
+python question_generation_pipeline/llm_decision_eval.py \
+  --local_only \
+  --dataset_path dataset/questions_final_519.jsonl \
+  --output_path outputs
+```
+
+The evaluator expects model responses to contain an answer in this form:
+
+```text
+Answer: [[C]]
+```
+
+Result CSVs include category, subcategory, question ID, raw response, extracted model choice, and correctness.
+
+## Generating new questions
+
+The multi-model question generator reads a doctrine/category CSV and writes JSONL MCQs:
+
+```bash
+python question_generation_pipeline/generate_mcqs_multi_llm.py \
+  --input_csv doctrine_categories_v3.csv \
+  --output_questions questions_generated_multi_llm_v3.jsonl \
+  --questions_per_model 12
+```
+
+Optional arguments include `--max_categories` for small test runs.
+
+## Analysis outputs
+
+Existing analysis artifacts include:
+
+- `data_analysis_&_outputs/accuracy_by_category_and_model.csv`: category-by-model accuracy matrix.
+- `data_analysis_&_outputs/most_missed_questions.csv`: questions most frequently missed across evaluated models.
+- `data_analysis_&_outputs/heatmap.png`: accuracy heatmap.
+- `data_analysis_&_outputs/refusal_heatmap_percent.png`: refusal-rate heatmap.
+- `llm_preformance_results/category_scores_by_model.csv`: long-form category score table.
+- `llm_preformance_results/refusal_phrase_counts_by_model.csv`: refusal summary by model.
+
+For exploratory analysis, open `data_analysis_&_outputs/llm_analysis.ipynb` in Jupyter after installing the requirements.
+
+## Notes and limitations
+
+- The benchmark is intended for research and educational evaluation, not operational decision support.
+- Questions are multiple-choice and source-backed, so scores measure answer selection under this format rather than complete operational competence.
+- Hosted-model results may vary over time as providers update model snapshots, APIs, and safety behavior.
+- Directory names with special characters, such as `data_analysis_&_outputs/`, may need quoting or escaping in shell commands.
 
 ## Contributing
 
-Contributions are welcome! If you have suggestions for improvements or new features, please open an issue or submit a pull request.
+Contributions are welcome. Please open an issue or pull request for dataset corrections, additional documentation, reproducibility improvements, or new analysis outputs.
+
+When contributing benchmark questions or results, include enough provenance to trace each item back to its source document and supporting evidence.
 
 ## Contact
 


### PR DESCRIPTION
### Motivation
- Clarify the repository purpose by rebranding to `ARMOR Benchmark 2025` and describe the benchmark scope (doctrine-grounded MCQ evaluation of LLMs). 
- Provide a concise developer/user-facing guide to the dataset, pipelines, and analysis artifacts to improve reproducibility and onboarding. 
- Document expected dataset schema and evaluation/generation workflows so consumers know input/output formats and required API keys. 

### Description
- Rewrote the top-level README to `ARMOR Benchmark 2025` and replaced the old overview with a repository contents table documenting `dataset/questions_final_519.jsonl`, `input_policy_documents/`, `question_generation_pipeline/`, `llm_preformance_results/`, `data_analysis_&_outputs/`, and `requirements.txt`.
- Added a `Dataset format` section that enumerates JSONL fields such as `qid`, `doc_source`, `category`, `generator_model`, `question`, `option_A/option_B/option_C(/option_D)`, `correct_option`, `supporting_evidence`, and `is_allowed_to_answer`.
- Added `Installation` and API key setup instructions with `pip install -r requirements.txt` and example environment variables for `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and `TOGETHER_API_KEY`.
- Added concrete usage examples for evaluation (`question_generation_pipeline/llm_decision_eval.py`) and generation (`question_generation_pipeline/generate_mcqs_multi_llm.py`), analysis artifacts list, notes/limitations, and contribution guidance.

### Testing
- Ran `git diff --check` which reported no style errors and the README modification is staged for commit. (passed)
- Executed a path-existence check via a short Python script validating that documented paths like `dataset/questions_final_519.jsonl`, `question_generation_pipeline/`, `llm_preformance_results/`, `data_analysis_&_outputs/`, and `requirements.txt` exist. (passed)
- Attempted to run `python question_generation_pipeline/llm_decision_eval.py --help && python question_generation_pipeline/generate_mcqs_multi_llm.py --help`, but the command failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'torch'`), so script runtime verification was not completed. (failed - dependency issue)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dcad49358832a93b94d92e0286737)