### PR TITLE
Update README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,101 @@
-# ARMOR Benchmark 2025
+# ARMOR-BENCH 2025
 
-ARMOR Benchmark 2025 is a doctrine-grounded benchmark for evaluating how large language models (LLMs) answer multiple-choice questions about military decision-making, law-of-war concepts, rules of engagement, and professional ethics. The benchmark is designed for educational and analytical evaluation of model behavior against source-backed policy documents.
+ARMOR-BENCH 2025 is a doctrine-grounded benchmark for evaluating how large language models (LLMs) answer multiple-choice questions about military decision-making, law-of-war concepts, rules of engagement, and professional ethics. The benchmark is intended for educational and analytical evaluation of model behavior against source-backed policy documents, not for operational decision support.
 
-## Citation
-This paper was published at the International Conference on Military Communications and Information Systems (ICMCIS).
-Paper: https://arxiv.org/abs/2605.00245
-Conference: https://icmcis.eu/
+## Publication and citation
 
-If you use this code or benchmark in your work, please cite our paper:
+The ARMOR-BENCH 2025 paper was published at the International Conference on Military Communications and Information Systems (ICMCIS).
+
+- Paper: <https://arxiv.org/abs/2605.00245>
+- Conference: <https://icmcis.eu/>
+
+If you use this dataset or benchmark outputs in your work, please cite the paper:
 
 ```bibtex
 @misc{johns2026armorbenchmark,
-  title        = {ARMOR-BENCH 2025: Evaluating Large Language Models for Military Decision-Making},
-  author       = {Johns, Sydney},
-  year         = {2026},
-  eprint       = {2605.00245},
+  title         = {ARMOR-BENCH 2025: Evaluating Large Language Models for Military Decision-Making},
+  author        = {Johns, Sydney},
+  year          = {2026},
+  eprint        = {2605.00245},
   archivePrefix = {arXiv},
-  primaryClass = {cs.AI},
-  url          = {https://arxiv.org/abs/2605.00245}
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2605.00245}
+}
 ```
 
-## What is in this repository?
-
-This repository contains the benchmark dataset, source doctrine PDFs, question-generation and model-evaluation scripts, and aggregate analysis outputs.
+## Repository contents
 
 | Path | Description |
 | --- | --- |
-| `dataset/questions_final_519.jsonl` | Final benchmark question set in JSON Lines format. Each record includes a question ID, source document, category, answer options, correct option, supporting evidence, and safety/answerability metadata. |
-| `input_policy_documents/` | Source policy and doctrine PDFs used to build the benchmark, including law-of-war, rules-of-engagement, and ethics references. |
-| `question_generation_pipeline/` | Scripts for cleaning doctrine text, generating MCQs with multiple LLMs, finding similar questions, and evaluating model answers. |
-| `llm_preformance_results/` | Per-model result CSVs and aggregated score/refusal summaries. The directory name is preserved as it appears in the project. |
-| `data_analysis_&_outputs/` | Analysis artifacts such as heatmaps, category-level accuracy tables, most-missed questions, similarity pairs, and the analysis notebook. |
-| `requirements.txt` | Python dependencies for generation, evaluation, and analysis workflows. |
+| `dataset/questions_final_519.jsonl` | Final benchmark question set in JSON Lines format. Each line is one multiple-choice question with source, category, options, answer key, supporting evidence, and answerability metadata. |
+| `input_policy_documents/` | Source doctrine and policy files used to construct the benchmark, including rules-of-engagement, law-of-war, and joint ethics references. |
+| `input_policy_documents/document_&_category_passages.xlsx` | Spreadsheet mapping source-document passages to benchmark categories. Quote or escape the path in shell commands because it contains `&`. |
+| `llm_preformance_results/` | Per-model response/evaluation CSVs plus aggregate category-score, refusal-rate, and similarity outputs. The directory name is preserved as it appears in the project. |
+| `requirements.txt` | Python dependencies useful for inspecting the dataset and reproducing related analysis workflows. |
 
-## Dataset format
+> **Note:** Earlier project workflows may have used generation/evaluation scripts that are not included in this repository snapshot. The files currently tracked here are the dataset, source documents, dependency list, and result artifacts.
 
-The final benchmark is stored at `dataset/questions_final_519.jsonl`. Each line is a JSON object with fields such as:
+## Dataset overview
+
+The final dataset contains **519** questions in `dataset/questions_final_519.jsonl`. Each line is a JSON object with fields such as:
 
 - `qid`: stable question identifier.
+- `span_id`: source-passage or generation-span identifier.
 - `doc_source`: source document family, for example `rules_of_engagement` or `law_of_war_2023`.
 - `category`: doctrinal category for the question.
 - `generator_model`: model family that generated the draft question.
-- `question`: the multiple-choice question text.
-- `option_A`, `option_B`, `option_C`, and optionally `option_D`: answer choices.
+- `question`: multiple-choice question text.
+- `option_A`, `option_B`, `option_C`, and, when present, `option_D`: answer choices.
 - `correct_option`: correct answer label.
 - `supporting_evidence`: source-backed evidence justifying the answer.
 - `is_allowed_to_answer`: whether the item is intended to be answerable in an educational/doctrinal setting.
+- `_source_file`: source generation file recorded for provenance.
 
-## Installation
+### Example record shape
+
+```json
+{
+  "qid": "rules_of_engagement__Mission-Specific_ROE_Constraints__ROW0001__gpt_Q01",
+  "span_id": "rules_of_engagement__Mission-Specific_ROE_Constraints__ROW0001__gpt",
+  "doc_source": "rules_of_engagement",
+  "category": "Mission-Specific ROE Constraints",
+  "generator_model": "gpt",
+  "question": "...",
+  "option_A": "...",
+  "option_B": "...",
+  "option_C": "...",
+  "correct_option": "C",
+  "supporting_evidence": "...",
+  "is_allowed_to_answer": "true",
+  "_source_file": "questions_generated_multi_llm.jsonl"
+}
+```
+
+## Result files
+
+Per-model result files in `llm_preformance_results/` follow this naming pattern:
+
+```text
+<model_name>_result.csv
+```
+
+These CSVs include:
+
+- `Category`
+- `Subcategory`
+- `QID`
+- `RawResponse`
+- `AIChoice`
+- `Result`
+
+Aggregate files include:
+
+- `llm_preformance_results/category_scores_by_model.csv`: category-level score summaries by model.
+- `llm_preformance_results/refusal_phrase_counts_by_model.csv`: refusal counts and refusal rates by model.
+- `llm_preformance_results/refusal_phrase_counts_by_category_all_models.csv`: refusal counts and refusal rates by category across models.
+- `llm_preformance_results/question_similarity_pairs.csv`: question-pair similarity output used to inspect possible overlap or duplication.
+
+## Getting started
 
 Create a Python environment and install dependencies:
 
@@ -57,7 +105,7 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Some workflows use hosted model APIs. Set only the keys needed for the providers you plan to run:
+Some exploratory workflows may use hosted model APIs. Set only the keys needed for the providers you plan to use:
 
 ```bash
 export OPENAI_API_KEY="..."
@@ -66,84 +114,55 @@ export GEMINI_API_KEY="..."
 export TOGETHER_API_KEY="..."
 ```
 
-Local Hugging Face model evaluation expects downloaded models under a project-local `models/` directory.
+## Inspecting the dataset
 
-## Evaluating models
-
-Use `question_generation_pipeline/llm_decision_eval.py` to evaluate online or local models against the JSONL benchmark.
-
-Evaluate one online model:
+Count records:
 
 ```bash
-python question_generation_pipeline/llm_decision_eval.py \
-  --online_only \
-  --model_name gpt-4o-2024-08-06 \
-  --dataset_path dataset/questions_final_519.jsonl \
-  --output_path outputs
+python - <<'PY'
+from pathlib import Path
+
+path = Path("dataset/questions_final_519.jsonl")
+print(sum(1 for _ in path.open()))
+PY
 ```
 
-Evaluate all configured online models:
+Preview the first question:
 
 ```bash
-python question_generation_pipeline/llm_decision_eval.py \
-  --online_only \
-  --dataset_path dataset/questions_final_519.jsonl \
-  --output_path outputs
+python - <<'PY'
+import json
+from pathlib import Path
+
+path = Path("dataset/questions_final_519.jsonl")
+with path.open() as handle:
+    first = json.loads(next(handle))
+print(json.dumps(first, indent=2))
+PY
 ```
 
-Evaluate local models from `models/` only:
+Load result summaries with pandas:
 
 ```bash
-python question_generation_pipeline/llm_decision_eval.py \
-  --local_only \
-  --dataset_path dataset/questions_final_519.jsonl \
-  --output_path outputs
+python - <<'PY'
+import pandas as pd
+
+scores = pd.read_csv("llm_preformance_results/category_scores_by_model.csv")
+print(scores.head())
+PY
 ```
-
-The evaluator expects model responses to contain an answer in this form:
-
-```text
-Answer: [[C]]
-```
-
-Result CSVs include category, subcategory, question ID, raw response, extracted model choice, and correctness.
-
-## Generating new questions
-
-The multi-model question generator reads a doctrine/category CSV and writes JSONL MCQs:
-
-```bash
-python question_generation_pipeline/generate_mcqs_multi_llm.py \
-  --input_csv doctrine_categories_v3.csv \
-  --output_questions questions_generated_multi_llm_v3.jsonl \
-  --questions_per_model 12
-```
-
-Optional arguments include `--max_categories` for small test runs.
-
-## Analysis outputs
-
-Existing analysis artifacts include:
-
-- `data_analysis_&_outputs/accuracy_by_category_and_model.csv`: category-by-model accuracy matrix.
-- `data_analysis_&_outputs/most_missed_questions.csv`: questions most frequently missed across evaluated models.
-- `data_analysis_&_outputs/heatmap.png`: accuracy heatmap.
-- `data_analysis_&_outputs/refusal_heatmap_percent.png`: refusal-rate heatmap.
-- `llm_preformance_results/category_scores_by_model.csv`: long-form category score table.
-- `llm_preformance_results/refusal_phrase_counts_by_model.csv`: refusal summary by model.
-
-For exploratory analysis, open `data_analysis_&_outputs/llm_analysis.ipynb` in Jupyter after installing the requirements.
 
 ## Notes and limitations
 
-- The benchmark is intended for research and educational evaluation, not operational decision support.
-- Questions are multiple-choice and source-backed, so scores measure answer selection under this format rather than complete operational competence.
-- Hosted-model results may vary over time as providers update model snapshots, APIs, and safety behavior.
-- Directory names with special characters, such as `data_analysis_&_outputs/`, may need quoting or escaping in shell commands.
+- ARMOR-BENCH 2025 is intended for research, education, and model-behavior analysis; it is not a substitute for expert legal, ethical, or command judgment.
+- Questions are multiple-choice and source-backed, so scores measure answer selection in this constrained format rather than complete operational competence.
+- Hosted-model behavior can change as providers update model snapshots, APIs, and safety systems.
+- Directory names with special characters, such as `input_policy_documents/document_&_category_passages.xlsx`, should be quoted or escaped in shell commands.
+- The result directory is named `llm_preformance_results/` in the repository; the spelling is intentionally preserved in this README so paths remain copy-pasteable.
 
 ## Contributing
 
-Contributions are welcome. Please open an issue or pull request for dataset corrections, additional documentation, reproducibility improvements, or new analysis outputs.
+Contributions are welcome. Please open an issue or pull request for dataset corrections, documentation improvements, reproducibility notes, or additional analysis artifacts.
 
 When contributing benchmark questions or results, include enough provenance to trace each item back to its source document and supporting evidence.
 


### PR DESCRIPTION
### Motivation
- Bring the README up to date with the files currently tracked in the repository and clarify the intended use and limitations of the benchmark. 
- Make dataset fields, provenance, and result-file shapes explicit so downstream users can inspect and reuse artifacts reliably. 
- Avoid implying operational use of the benchmark by clarifying it is for education and research only. 

### Description
- Rename and reframe the top-level title and purpose text to `ARMOR-BENCH 2025` and add an explicit disclaimer that it is not for operational decision support. 
- Refresh the Publication/Citation section and fix the BibTeX entry formatting. 
- Replace the repository-contents and dataset-format sections with a concise `Repository contents` and `Dataset overview` that list tracked files, dataset fields (including `span_id` and `_source_file`), and an example JSON record. 
- Add simple, copy-pasteable inspection commands (counting records and previewing the first JSONL entry) and example pandas loading for result summaries, and explicitly note the preserved `llm_preformance_results/` directory name. 

### Testing
- Ran a validation script via `python - <<'PY' ... PY` that confirmed the JSONL contains `519` records and that every record includes the required fields, and that CSV result files have headers, which succeeded. 
- Ran `git diff --check` to verify there are no whitespace/format issues, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aef725770832aa72d506b5d6a6fb0)